### PR TITLE
fields validation and type conversion

### DIFF
--- a/mongonaut/forms.py
+++ b/mongonaut/forms.py
@@ -3,7 +3,7 @@ import logging
 from django import forms
 
 from mongoengine.fields import Document, ReferenceField
-from mongonaut.widgets import get_widget
+from mongonaut.widgets import get_widget, get_form_field_class
 
 logger = logging.getLogger('mongonaut.forms')
 
@@ -51,7 +51,8 @@ def document_detail_form_factory(form, document_type, initial=False):
                 required=field.required,
                 widget=widget)
         else:
-            form.fields[key] = forms.CharField(
+            form_class = get_form_field_class(field)
+            form.fields[key] = form_class(
                 key,
                 required=field.required,
                 widget=widget)

--- a/mongonaut/views.py
+++ b/mongonaut/views.py
@@ -252,13 +252,6 @@ class DocumentEditFormView(MongonautViewMixin, FormView):
                         setattr(self.document, key, datetime.strptime(self.request.POST[key], format))
                         continue
 
-                    if isinstance(field.widget, CheckboxInput):
-                        if key in self.request.POST:
-                            setattr(self.document, key, True)
-                        else:
-                            setattr(self.document, key, False)
-                        continue
-
                     if isinstance(field.widget, widgets.Select):
                         # supporting reference fields!
                         value = field.mongofield.document_type.objects.get(id=self.request.POST[key])
@@ -266,7 +259,7 @@ class DocumentEditFormView(MongonautViewMixin, FormView):
                         continue
 
                     # for strings
-                    setattr(self.document, key, self.request.POST[key])
+                    setattr(self.document, key, self.form.cleaned_data[key])
 
                 self.document.save()
                 messages.add_message(self.request, messages.INFO, 'Your changes have been saved.')

--- a/mongonaut/widgets.py
+++ b/mongonaut/widgets.py
@@ -8,6 +8,12 @@ from mongoengine.fields import DateTimeField
 from mongoengine.fields import EmbeddedDocumentField
 from mongoengine.fields import ListField
 from mongoengine.fields import ReferenceField
+from mongoengine.fields import FloatField
+from mongoengine.fields import EmailField
+from mongoengine.fields import DecimalField
+from mongoengine.fields import URLField
+from mongoengine.fields import IntField
+from mongoengine.fields import StringField
 
 
 def get_widget(field, disabled=False):
@@ -35,3 +41,19 @@ def get_widget(field, disabled=False):
         return forms.Select(attrs=attrs)
 
     return forms.TextInput(attrs=attrs)
+
+
+MAPPING = {
+    IntField: forms.IntegerField,
+    StringField: forms.CharField,
+    FloatField: forms.FloatField,
+    BooleanField: forms.BooleanField,
+    DateTimeField: forms.DateTimeField,
+    DecimalField: forms.DecimalField,
+    URLField: forms.URLField,
+    EmailField: forms.EmailField
+}
+
+
+def get_form_field_class(field):
+    return MAPPING.get(field.__class__, forms.CharField)


### PR DESCRIPTION
I was trying to save a FloatField but it looks like the value that was passed to the mongo was a unicode string.

This small change is using django's form fields to validate input and convert strings to the respective native data type.

I suppose this is a first step, date&time data should be handled similar way to avoid repetitions.

Let me know what do you think.
