### PR TITLE
Fixing "django.conf.urls.defaults is deprecated"

### DIFF
--- a/examples/blog/articles/urls.py
+++ b/examples/blog/articles/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, include, url
+from django.conf.urls import patterns, include, url
 from django.views.generic import ListView
 
 from articles.models import Post

--- a/examples/blog/urls.py
+++ b/examples/blog/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, include, url
+from django.conf.urls import patterns, include, url
 
 
 urlpatterns = patterns('',

--- a/mongonaut/urls.py
+++ b/mongonaut/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 
 from mongonaut import views


### PR DESCRIPTION
With Django 1.5.1:

```
DeprecationWarning: django.conf.urls.defaults is deprecated; use django.conf.urls instead
```
