### PR TITLE
Fix search

### DIFF
--- a/mongonaut/views.py
+++ b/mongonaut/views.py
@@ -80,7 +80,7 @@ class DocumentListView(MongonautViewMixin, FormView):
         # search. move this to get_queryset
         # search. move this to get_queryset
         q = self.request.GET.get('q')
-        self.get_qset(queryset, q)
+        queryset = self.get_qset(queryset, q)
 
         ### Start pagination
         ### Note:


### PR DESCRIPTION
The filter is applied but the result is not saved back to the `queryset` variable. Because of this, the search does not actually work, it simply shows full list irrespective of search param currently.
