### PR TITLE
Patched for Python 3

### DIFF
--- a/mongonaut/mixins.py
+++ b/mongonaut/mixins.py
@@ -60,7 +60,7 @@ class MongonautViewMixin(object):
             try:
                 module = import_module(mongoadmin)
             except ImportError as e:
-                if str(e) == "No module named mongoadmin":
+                if str(e).startswith("No module named"):
                     continue
                 raise e
 

--- a/setup.py
+++ b/setup.py
@@ -51,4 +51,5 @@ setup(
     include_package_data=True,
     install_requires=['mongoengine>=0.5.2'],
     zip_safe=False,
+    use_2to3 = True,
 )


### PR DESCRIPTION
Added 2to3 to setup.py and did the simplest patch possible for the updated ImportError message in Python 3. Tests pass on Python 3.3, happy-testing the UI seems to work.
