### PR TITLE
Added travis config to ignore unittest2 in Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   - DJANGO=1.6
 install:
   - pip install -q Django==$DJANGO --use-mirrors
-  - pip install unittest2
+  - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then pip install unittest2; fi
   - pip install -q -e . --use-mirrors
 services:
   - mongodb


### PR DESCRIPTION
Only install unittest2 for Python 2x
