### PR TITLE
added '{% load url from future %}' in templates for backward compatibility

### DIFF
--- a/mongonaut/templates/mongonaut/document_add_form.html
+++ b/mongonaut/templates/mongonaut/document_add_form.html
@@ -1,4 +1,5 @@
 {% extends "mongonaut/base.html" %}
+{% load url from future %}
 {% load mongonaut_tags %}
 
 {% block breadcrumbs %}

--- a/mongonaut/templates/mongonaut/document_delete.html
+++ b/mongonaut/templates/mongonaut/document_delete.html
@@ -1,4 +1,5 @@
 {% extends "mongonaut/base.html" %}
+{% load url from future %}
 {% load mongonaut_tags %}
 
 {% block breadcrumbs %}

--- a/mongonaut/templates/mongonaut/document_detail.html
+++ b/mongonaut/templates/mongonaut/document_detail.html
@@ -1,4 +1,5 @@
 {% extends "mongonaut/base.html" %}
+{% load url from future %}
 {% load mongonaut_tags %}
 
 {% block breadcrumbs %}

--- a/mongonaut/templates/mongonaut/document_edit_form.html
+++ b/mongonaut/templates/mongonaut/document_edit_form.html
@@ -1,4 +1,5 @@
 {% extends "mongonaut/base.html" %}
+{% load url from future %}
 {% load mongonaut_tags %}
 
 {% block breadcrumbs %}

--- a/mongonaut/templates/mongonaut/document_list.html
+++ b/mongonaut/templates/mongonaut/document_list.html
@@ -1,4 +1,5 @@
 {% extends "mongonaut/base.html" %}
+{% load url from future %}
 {% load mongonaut_tags %}
 
 {% block breadcrumbs %}

--- a/mongonaut/templates/mongonaut/index.html
+++ b/mongonaut/templates/mongonaut/index.html
@@ -1,4 +1,5 @@
 {% extends "mongonaut/base.html" %}
+{% load url from future %}
 {% load mongonaut_tags %}
 
 {% block breadcrumbs %}


### PR DESCRIPTION
added '{% load url from future %}' in templates for backward compatibility with django 1.4 and before, for more info checkout django 1.5 changelog.
Summarising the same: if you are not using {% load url from future %} in your templates, you’ll need to change tags like {% url myview %} to {% url "myview" %}. If you were using {% load url from future %} you can simply remove that line under Django 1.5
