### PR TITLE
Modifying the permission message.

### DIFF
--- a/mongonaut/mixins.py
+++ b/mongonaut/mixins.py
@@ -32,7 +32,7 @@ class MongonautViewMixin(object):
 
     def render_to_response(self, context, **response_kwargs):
         if hasattr(self, 'permission') and not self.request.user.has_perm(self.permission):
-            return HttpResponseForbidden("You do not have permissions to access this content.")
+            return HttpResponseForbidden("You do not have permissions to access this content. Login as a superuser to view and edit data.")
 
         return self.response_class(
             request=self.request,


### PR DESCRIPTION
Many people does't know that they have to login as a superuser to view the mongo admin interface , People get confused when they read the message(_You do not have permissions to access this content_).
This commit has an updated message. Please provide the right message if this is not correct.