### PR TITLE
adds self.request to the context variables

### DIFF
--- a/mongonaut/views.py
+++ b/mongonaut/views.py
@@ -131,6 +131,7 @@ class DocumentListView(MongonautViewMixin, FormView):
         context['document'] = self.document
         context['app_label'] = self.app_label
         context['document_name'] = self.document_name
+        context['request'] = self.request
 
         # pagination bits
         context['page'] = self.page


### PR DESCRIPTION
Couldn't find the delete functionality in the document lists, even though the logged in user is a superuser. Tried to print the request object in the template and it was none. 
Added the request object in the context variable so that the request  will be available in the template.