### PR TITLE
Fix search results for 1 result in python2 compatibility and add support for GeoPointField

### DIFF
--- a/mongonaut/forms/widgets.py
+++ b/mongonaut/forms/widgets.py
@@ -16,6 +16,7 @@ from mongoengine.fields import DecimalField
 from mongoengine.fields import URLField
 from mongoengine.fields import IntField
 from mongoengine.fields import StringField
+from mongoengine.fields import GeoPointField
 
 
 def get_widget(model_field, disabled=False):
@@ -35,7 +36,9 @@ def get_widget(model_field, disabled=False):
     elif isinstance(model_field, ReferenceField) or model_field.choices:
         return forms.Select(attrs=attrs)
 
-    elif isinstance(model_field, ListField) or isinstance(model_field, EmbeddedDocumentField):
+    elif (isinstance(model_field, ListField) or
+          isinstance(model_field, EmbeddedDocumentField) or
+          isinstance(model_field, GeoPointField)):
         return None
 
     else:

--- a/mongonaut/views.py
+++ b/mongonaut/views.py
@@ -101,7 +101,7 @@ class DocumentListView(MongonautViewMixin, FormView):
             self.page = 1
 
         obj_count = queryset.count()
-        self.total_pages = math.ceil(obj_count / self.documents_per_page)
+        self.total_pages = math.ceil(float(obj_count) / self.documents_per_page)
 
         if self.page < 1:
             self.page = 1

--- a/mongonaut/views.py
+++ b/mongonaut/views.py
@@ -101,13 +101,13 @@ class DocumentListView(MongonautViewMixin, FormView):
             self.page = 1
 
         obj_count = queryset.count()
-        self.total_pages = math.ceil(float(obj_count) / self.documents_per_page)
-
-        if self.page < 1:
-            self.page = 1
+        self.total_pages = math.ceil(obj_count / self.documents_per_page)
 
         if self.page > self.total_pages:
             self.page = self.total_pages
+
+        if self.page < 1:
+            self.page = 1
 
         start = (self.page - 1) * self.documents_per_page
         end = self.page * self.documents_per_page


### PR DESCRIPTION
When only 1 result is returned from search query it is possible to get negative indexes which are not supported in mongoengine.

Also add support for GeoPointField so it does not break edit when it is present on a model.