### PR TITLE
Old style exceptions --> new style for Python 3

### DIFF
--- a/tests/url_tests.py
+++ b/tests/url_tests.py
@@ -44,7 +44,7 @@ class IndexViewTests(unittest.TestCase):
 
         try:
             v = get_document_value(p, 'author')
-        except NoReverseMatch, e:
+        except NoReverseMatch as e:
             match_found = False
 
         settings.ROOT_URLCONF = urls_tmp
@@ -76,7 +76,7 @@ class IndexViewTests(unittest.TestCase):
 
         try:
             self.view.render()
-        except NoReverseMatch, e:
+        except NoReverseMatch as e:
             match_found = False
 
         settings.ROOT_URLCONF = urls_tmp
@@ -106,7 +106,7 @@ class IndexViewTests(unittest.TestCase):
         try:
             res = get_document_value(p, 'author')
             unicode_ok = True
-        except UnicodeEncodeError, e:
+        except UnicodeEncodeError as e:
             pass
 
         self.assertTrue(unicode_ok)


### PR DESCRIPTION
Old style exceptions are syntax errors in Python 3

[flake8](http://flake8.pycqa.org) testing of https://github.com/jazzband/django-mongonaut on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./mongonaut/forms/form_mixins.py:160:55: F821 undefined name 'field_key'
                        embedded_key_class = make_key(field_key, exclude_last_string=True)
                                                      ^
./tests/url_tests.py:47:30: E999 SyntaxError: invalid syntax
        except NoReverseMatch, e:
                             ^
1     E999 SyntaxError: invalid syntax
1     F821 undefined name 'field_key'
2
```